### PR TITLE
Tweak action metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,8 @@
-name: 'ZAP Baseline Scan'
-description: 'Scans the web application with ZAP Baseline Scan'
+name: 'OWASP ZAP Baseline Scan'
+description: 'Scans the web application with the OWASP ZAP Baseline Scan'
+branding:
+  icon: 'zap'
+  color: 'blue'
 inputs:
   token:
     description: 'GitHub Token to create issues in the repository'


### PR DESCRIPTION
Change to OWASP ZAP in name/description to be more clear.
Add branding (zap/blue).