### PR TITLE
Use a convenient default for github token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,8 @@ branding:
 inputs:
   token:
     description: 'GitHub Token to create issues in the repository'
-    required: true
+    required: false
+    default: ${{ github.token }}
   target:
     description: 'Target URL'
     required: true


### PR DESCRIPTION
The vast majority of users will be providing this value manually. Making it the default eliminates a bit of configuration that shouldn't be necessary for most users.