### PR TITLE
Skip create/update issue if token is empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,10 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName);
+        
+        if (token !== '') {
+            await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName);
+        }
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
The [documentation](https://github.com/marketplace/actions/owasp-zap-baseline-scan#token) currently states that "If you don’t want ZAP to create GitHub issues, set the token to an empty string", however this doesn't seem to be working, possibly because the GitHub base action already has a token introduced; this fixes that by bypassing the issues creation/updating if the token is empty.