### PR TITLE
Allow operators to control issue filing using new Action input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this GitHub action will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+ - An input (`allow_issue_writing`) to choose if a GitHub issue should be raised or not. [#56](https://github.com/zaproxy/action-baseline/issues/56)
+
 ### Changed
 - Update dependencies.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Make sure to checkout the repository (actions/checkout@v2) to provide the ZAP ru
 
 **Optional** Additional command lines options for the baseline script
 
+### `allow_issue_writing`
+
+**Optional** By default the baseline action will file the report to the GitHub issue using the `issue_title` input.
+Set this to false if you don't want the issue to be created or updated.
+
 ### `issue_title`
 
 **Optional** The title for the GitHub issue to be created
@@ -40,7 +45,7 @@ Make sure to checkout the repository (actions/checkout@v2) to provide the ZAP ru
 ### `token`
 
 **Optional** ZAP action uses the default action token provided by GitHub to create and update the issue for the baseline scan.
-You do not have to create a dedicated token. Make sure to use the GitHub's default action token when running the action(`secrets.GITHUB_TOKEN`). If you don’t want ZAP to create GitHub issues, set the token to an empty string.
+You do not have to create a dedicated token. Make sure to use the GitHub's default action token when running the action(`secrets.GITHUB_TOKEN`).
 
 ### `fail_action`
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'The action status will be set to fail if ZAP identifies any alerts during the baseline scan'
     required: false
     default: false
+  allow_issue_writing:
+    description: 'The action will file the report to the GitHub issue using the issue_title input'
+    required: false
+    default: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3808,6 +3808,7 @@ async function run() {
         let cmdOptions = core.getInput('cmd_options');
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
+        let allowIssueWriting = core.getInput('allow_issue_writing');
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');
@@ -3845,7 +3846,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting);
     } catch (error) {
         core.setFailed(error.message);
     }
@@ -20354,10 +20355,15 @@ const _ = __webpack_require__(557);
 const actionHelper = __webpack_require__(174);
 
 let actionCommon = {
-    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName) => {
+    processReport: (async (token, workSpace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting = true) => {
         let jsonReportName = 'report_json.json';
         let mdReportName = 'report_md.md';
         let htmlReportName = 'report_html.html';
+
+        if (!allowIssueWriting) {
+            actionHelper.uploadArtifacts(workSpace, mdReportName, jsonReportName, htmlReportName);
+            return;
+        }
 
         let openIssue;
         let currentReport;

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ async function run() {
         let cmdOptions = core.getInput('cmd_options');
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
+        let allowIssueWriting = core.getInput('allow_issue_writing');
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');
@@ -58,7 +59,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, allowIssueWriting);
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -766,9 +766,9 @@
       "dev": true
     },
     "@zaproxy/actions-common-scans": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-0.1.0.tgz",
-      "integrity": "sha512-yfXPuoNWMHQSfY3TII2rm/8NALCvGFn9lT5N/N5SzjuqVBrc6mO8dxgDJnWAdnKRgqTjWVOX8lBX2xziwmKm2A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-0.2.0.tgz",
+      "integrity": "sha512-Xv7dYtNLtXCG2rPXzJa+iIkIqFPsrzcM2d2tWlx3taElz/7bRQqt04ZgBBA0m2W1Xh88QspZ3f49+2KRFwm9qw==",
       "requires": {
         "@actions/artifact": "^0.2.0",
         "@actions/core": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.0",
     "@actions/github": "^1.0.0",
-    "@zaproxy/actions-common-scans": "^0.1.0",
+    "@zaproxy/actions-common-scans": "^0.2.0",
     "adm-zip": "^0.4.14",
     "d3-dsv": "^1.2.0",
     "github-api": "^3.3.0",


### PR DESCRIPTION
Use the allowIssueWriting boolean to control whether a GitHub issue is updated or created as a result of report creation.

Fix #56.