### PR TITLE
Add artifact name as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this GitHub action will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+ - An input (`artifact_name`) used to name the artifact that contains the ZAP reports. [#45](https://github.com/zaproxy/action-baseline/issues/45)
+
 ### Changed
 - Run action with Node 16.
 - Update dependencies.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ You do not have to create a dedicated token. Make sure to use the GitHub's defau
 **Optional** By default ZAP Docker container will fail with an [exit code](https://github.com/zaproxy/zaproxy/blob/efb404d38280dc9ecf8f88c9b0c658385861bdcf/docker/zap-baseline.py#L31), 
 if it identifies any alerts. Set this option to `true` if you want to fail the status of the GitHub Scan if ZAP identifies any alerts during the scan.  
 
+### `artifact_name`
+
+**Optional** By default the baseline action will attach the report to the build with the name `zap_scan`. Set this to a different string to name it something else. Consult [GitHub's documentation](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md#non-supported-characters) for which artifact names are allowed.
+
 ## Example usage
 
 ** Basic **

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'The action will file the report to the GitHub issue using the issue_title input'
     required: false
     default: true
+  artifact_name:
+    description: 'The name of the artifact that contains the ZAP reports'
+    required: false
+    default: 'zap_scan'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -38335,6 +38335,7 @@ async function run() {
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
         let allowIssueWriting = core.getInput('allow_issue_writing');
+        let artifactName = core.getInput('artifact_name');
         let createIssue = true;
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
@@ -38343,6 +38344,11 @@ async function run() {
 
         if (String(allowIssueWriting).toLowerCase() === 'false') {
             createIssue = false;
+        }
+
+        if (!artifactName) {
+            console.log('[WARNING]: \'artifact_name\' action input should not be empty. Setting it back to the default name.');
+            artifactName = 'zap_scan';
         }
 
         console.log('starting the program');
@@ -38381,7 +38387,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue, artifactName);
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ async function run() {
         let issueTitle = core.getInput('issue_title');
         let failAction = core.getInput('fail_action');
         let allowIssueWriting = core.getInput('allow_issue_writing');
+        let artifactName = core.getInput('artifact_name');
         let createIssue = true;
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
@@ -30,6 +31,11 @@ async function run() {
 
         if (String(allowIssueWriting).toLowerCase() === 'false') {
             createIssue = false;
+        }
+
+        if (!artifactName) {
+            console.log('[WARNING]: \'artifact_name\' action input should not be empty. Setting it back to the default name.');
+            artifactName = 'zap_scan';
         }
 
         console.log('starting the program');
@@ -68,7 +74,7 @@ async function run() {
                 console.log('Scanning process completed, starting to analyze the results!')
             }
         }
-        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue);
+        await common.main.processReport(token, workspace, plugins, currentRunnerID, issueTitle, repoName, createIssue, artifactName);
     } catch (error) {
         core.setFailed(error.message);
     }


### PR DESCRIPTION
Allow users to configure custom report names by providing an optional Action input. Requires this to go in: https://github.com/zaproxy/actions-common/pull/15

Merging in both resolves https://github.com/zaproxy/action-baseline/issues/45