### PR TITLE
Use default user instead of root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update dependencies.
 
+### Fixed
+- Use default zap user rather than root to allow the Ajax Spider to run.
+
 ## [0.6.1] - 2021-10-08
 ### Changed
 - Revert previous change (not into effect), no longer needed.

--- a/dist/index.js
+++ b/dist/index.js
@@ -3859,8 +3859,12 @@ async function run() {
             plugins = await common.helper.processLineByLine(`${workspace}/${rulesFileLocation}`);
         }
 
+        // Create the files so we can change the perms and allow the docker non root user to update them
+        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run --user root -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
             `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {

--- a/index.js
+++ b/index.js
@@ -40,8 +40,12 @@ async function run() {
             plugins = await common.helper.processLineByLine(`${workspace}/${rulesFileLocation}`);
         }
 
+        // Create the files so we can change the perms and allow the docker non root user to update them
+        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run --user root -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
             `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {


### PR DESCRIPTION
Seems to generate the files fine: https://github.com/psiinon/action-baseline/actions/runs/2358500707

fixes #33

Will PR the same change to the API & full scans once we've double checked this works fine.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>