### PR TITLE
Update branch name for checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
       - name: ZAP Scan
         uses: zaproxy/action-baseline@v0.7.0
         with:


### PR DESCRIPTION
The branch name for actions/checkout@v2 was renamed to `main`.  

You can verify  that in the repo: [https://github.com/actions/checkout](https://github.com/actions/checkout) 

Signed-off-by: Lindsay Young <Lindsay.n.young@gmail.com>

Thank you!