### PR TITLE
Allow to choose the name of report files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ You do not have to create a dedicated token. Make sure to use the GitHub's defau
 **Optional** By default ZAP Docker container will fail with an [exit code](https://github.com/zaproxy/zaproxy/blob/efb404d38280dc9ecf8f88c9b0c658385861bdcf/docker/zap-baseline.py#L31), 
 if it identifies any alerts. Set this option to `true` if you want to fail the status of the GitHub Scan if ZAP identifies any alerts during the scan.  
 
+### `json_report_name`
+
+**Optional** File to write the full ZAP HTML report
+
+### `md_report_name`
+
+**Optional** File to write the full ZAP Wiki (Markdown) report
+
+### `html_report_name`
+
+**Optional** File to write the full ZAP HTML report
+
+
+
 ## Example usage
 
 ** Basic **

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,19 @@ inputs:
     description: 'The action will file the report to the GitHub issue using the issue_title input'
     required: false
     default: true
+  json_report_name:
+    description: 'file to write the full ZAP JSON document'
+    required: false
+    default: 'report_json.json'
+  md_report_name:
+    description: 'file to write the full ZAP Wiki (Markdown) report'
+    required: false
+    default: 'report_md.md'
+  html_report_name:
+    description: 'file to write the full ZAP HTML report'
+    required: false
+    default: 'report_html.html'
+
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -3,11 +3,6 @@ const exec = require('@actions/exec');
 const common = require('@zaproxy/actions-common-scans');
 const _ = require('lodash');
 
-// Default file names
-let jsonReportName = 'report_json.json';
-let mdReportName = 'report_md.md';
-let htmlReportName = 'report_html.html';
-
 async function run() {
 
     try {
@@ -23,6 +18,9 @@ async function run() {
         let failAction = core.getInput('fail_action');
         let allowIssueWriting = core.getInput('allow_issue_writing');
         let createIssue = true;
+        let jsonReportName = core.getInput("json_report_name");
+        let mdReportName = core.getInput("md_report_name");
+        let htmlReportName = core.getInput("html_report_name");
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');


### PR DESCRIPTION
feat: parameterize-output-files to avoid report override when runs for multiple target in same workflow