### PR TITLE
Update dependency and release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this GitHub action will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.8.2] - 2023-07-04
+### Fixed
+- Fix an issue introduced in the previous release that prevented the use of the default GitHub authentication token to raise issues.
 
 ## [0.8.1] - 2023-07-03
 ### Fixed
@@ -65,7 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 First release to Marketplace.
 
-[Unreleased]: https://github.com/zaproxy/action-baseline/compare/v0.8.1...HEAD
+[0.8.2]: https://github.com/zaproxy/action-baseline/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/zaproxy/action-baseline/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/zaproxy/action-baseline/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/zaproxy/action-baseline/compare/v0.6.1...v0.7.0

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ if it identifies any alerts. Set this option to `true` if you want to fail the s
 ```
 steps:
   - name: ZAP Scan
-    uses: zaproxy/action-baseline@v0.8.1
+    uses: zaproxy/action-baseline@v0.8.2
     with:
       target: 'https://www.zaproxy.org'
 ```
@@ -82,7 +82,7 @@ jobs:
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-baseline@v0.8.1
+        uses: zaproxy/action-baseline@v0.8.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'owasp/zap2docker-stable'

--- a/dist/index.js
+++ b/dist/index.js
@@ -8081,12 +8081,17 @@ const actionCommon = {
             create_new_issue = true;
         }
         else {
-            const user = (await octokit.users.getAuthenticated()).data;
+            let login = "github-actions[bot]";
+            try {
+                login = (await octokit.users.getAuthenticated()).data.login;
+            }
+            catch (e) {
+                console.log(`Using ${login} to serch for issues.`);
+            }
             // Sometimes search API returns recently closed issue as an open issue
             for (let i = 0; i < issues.data.items.length; i++) {
                 const issue = issues.data.items[i];
-                if (issue["state"] === "open" &&
-                    issue["user"]["login"] === user.login) {
+                if (issue["state"] === "open" && issue["user"]["login"] === login) {
                     openIssue = issue;
                     break;
                 }
@@ -8109,7 +8114,7 @@ const actionCommon = {
                     let lastBotComment;
                     const lastCommentIndex = comments["data"].length - 1;
                     for (let i = lastCommentIndex; i >= 0; i--) {
-                        if (comments["data"][i]["user"]["login"] === user.login) {
+                        if (comments["data"][i]["user"]["login"] === login) {
                             lastBotComment = comments["data"][i];
                             break;
                         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
-        "@zaproxy/actions-common-scans": "^1.0.1",
+        "@zaproxy/actions-common-scans": "^1.0.2",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@zaproxy/actions-common-scans": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-1.0.1.tgz",
-      "integrity": "sha512-b0wu1ltoeBvpI87igo+Uh8UXDEEmoxKyoWKuNoWC9bTF2Kc0yLFjA64WzkiXVIzexXosnukAttjSjO9bHGwLvQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-1.0.2.tgz",
+      "integrity": "sha512-MfhVLSdsSN85B4nZkRC7yUq2BGN7DCjE/jT2LV2x8nFbfUswopptXyb+puX59C0vtP0cvil75mLiTlNCACg9kQ==",
       "dependencies": {
         "@actions/artifact": "^1.1.0",
         "@actions/github": "^5.1.1",
@@ -564,9 +564,9 @@
       "dev": true
     },
     "@zaproxy/actions-common-scans": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-1.0.1.tgz",
-      "integrity": "sha512-b0wu1ltoeBvpI87igo+Uh8UXDEEmoxKyoWKuNoWC9bTF2Kc0yLFjA64WzkiXVIzexXosnukAttjSjO9bHGwLvQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@zaproxy/actions-common-scans/-/actions-common-scans-1.0.2.tgz",
+      "integrity": "sha512-MfhVLSdsSN85B4nZkRC7yUq2BGN7DCjE/jT2LV2x8nFbfUswopptXyb+puX59C0vtP0cvil75mLiTlNCACg9kQ==",
       "requires": {
         "@actions/artifact": "^1.1.0",
         "@actions/github": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
-    "@zaproxy/actions-common-scans": "^1.0.1",
+    "@zaproxy/actions-common-scans": "^1.0.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {


### PR DESCRIPTION
Update `actions-common-scans` to latest version to fix the use of default auth token.
Update changelog and readme for release.