### PR TITLE
added default xml report file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this GitHub action will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Fix an issue where XML report file is not generated which caused no XML report to be generated. [#104](https://github.com/zaproxy/action-baseline/issues/104)
 
 ## [0.8.2] - 2023-07-04
 ### Fixed

--- a/dist/index.js
+++ b/dist/index.js
@@ -38326,6 +38326,7 @@ const _ = __nccwpck_require__(250);
 let jsonReportName = 'report_json.json';
 let mdReportName = 'report_md.md';
 let htmlReportName = 'report_html.html';
+let xmlReportName = 'report_xml.xml';
 
 async function run() {
 
@@ -38366,12 +38367,12 @@ async function run() {
         }
 
         // Create the files so we can change the perms and allow the docker non root user to update them
-        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
-        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName} ${xmlReportName}`);
+        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName} ${xmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
         let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
-            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
+            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName} -x ${xmlReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {
             command = command + ` -c ${rulesFileLocation}`

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 let jsonReportName = 'report_json.json';
 let mdReportName = 'report_md.md';
 let htmlReportName = 'report_html.html';
+let xmlReportName = 'report_xml.xml';
 
 async function run() {
 
@@ -47,12 +48,12 @@ async function run() {
         }
 
         // Create the files so we can change the perms and allow the docker non root user to update them
-        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
-        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName} ${xmlReportName}`);
+        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName} ${xmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
         let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
-            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
+            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName} -x ${xmlReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {
             command = command + ` -c ${rulesFileLocation}`


### PR DESCRIPTION
Currently using -x flag fails as a default xml file is not being created. XML reports are needed if using dashboarding tools such as DefectDojo as it cannot parse the other file formats produced.

Fix #104