### PR TITLE
Update names and default Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this GitHub action will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- The default Docker image was changed to `ghcr.io/zaproxy/zaproxy:stable`.
 
 ## [0.8.2] - 2023-07-04
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Action Baseline
 
-A GitHub Action for running the OWASP ZAP [Baseline scan](https://www.zaproxy.org/docs/docker/baseline-scan/) to find vulnerabilities in your web application. 
+A GitHub Action for running the ZAP [Baseline scan](https://www.zaproxy.org/docs/docker/baseline-scan/) to find vulnerabilities in your web application. 
  
 The ZAP baseline action scans a target URL for vulnerabilities and maintains an issue in GitHub repository for the
 identified alerts. Read the following [blog post](https://www.zaproxy.org/blog/2020-04-09-automate-security-testing-with-zap-and-github-actions) 
@@ -85,7 +85,7 @@ jobs:
         uses: zaproxy/action-baseline@v0.8.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           target: 'https://www.zaproxy.org'
           rules_file_name: '.zap/rules.tsv'
           cmd_options: '-a'
@@ -113,8 +113,6 @@ the actions bot will close the ongoing open issue.
 ZAP is internationalised and alert information is available in many languages.
 
 You can change the language used by this action by changing the locale via the `cmd_options` e.g.: `-z "-config view.locale=fr_FR"`
-
-This is currently only available with the `owasp/zap2docker-weekly` or `owasp/zap2docker-live` Docker images.
 
 See [https://github.com/zaproxy/zaproxy/tree/main/zap/src/main/dist/lang](https://github.com/zaproxy/zaproxy/tree/main/zap/src/main/dist/lang) for the full set of locales currently supported.
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'OWASP ZAP Baseline Scan'
-description: 'Scans the web application with the OWASP ZAP Baseline Scan'
+name: 'ZAP Baseline Scan'
+description: 'Scans the web application with the ZAP Baseline Scan'
 branding:
   icon: 'zap'
   color: 'blue'
@@ -17,7 +17,7 @@ inputs:
   docker_name:
     description: 'The Docker file to be executed'
     required: true
-    default: 'owasp/zap2docker-stable'
+    default: 'ghcr.io/zaproxy/zaproxy:stable'
   cmd_options:
     description: 'Additional command line options'
     required: false


### PR DESCRIPTION
Remove OWASP references.
Use Docker image from GHCR.
Remove outdated note in the readme.