### PR TITLE
[WIP] Generate sarif support by default

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38326,6 +38326,7 @@ const _ = __nccwpck_require__(250);
 let jsonReportName = 'report_json.json';
 let mdReportName = 'report_md.md';
 let htmlReportName = 'report_html.html';
+let sarifReportName = "report.sarif.json"
 
 async function run() {
 
@@ -38366,12 +38367,12 @@ async function run() {
         }
 
         // Create the files so we can change the perms and allow the docker non root user to update them
-        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
-        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName} ${sarifReportName}`);
+        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName} ${sarifReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
         let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
-            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
+            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} -S ${sarifReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {
             command = command + ` -c ${rulesFileLocation}`

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 let jsonReportName = 'report_json.json';
 let mdReportName = 'report_md.md';
 let htmlReportName = 'report_html.html';
+let sarifReportName = "report.sarif.json"
 
 async function run() {
 
@@ -47,12 +48,12 @@ async function run() {
         }
 
         // Create the files so we can change the perms and allow the docker non root user to update them
-        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
-        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName} ${sarifReportName}`);
+        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName} ${sarifReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
         let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
-            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
+            `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} -S ${sarifReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {
             command = command + ` -c ${rulesFileLocation}`


### PR DESCRIPTION
Goal is to address https://github.com/zaproxy/action-baseline/issues/63 and start the work to support the Code Scanning integration

To work fully this requires changes to `zap-baseline.py` and `zap_common.py` to properly support the sarif report
(https://github.com/zaproxy/zaproxy/pull/8005)