### PR TITLE
Pass ZAP auth env vars and release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this GitHub action will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.10.0] - 2023-10-31
+### Added
+- Support for authentication environment variables.
+
 ### Fixed
 - Update Crowdin link.
 
@@ -75,7 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 First release to Marketplace.
 
-[Unreleased]: https://github.com/zaproxy/action-baseline/compare/v0.9.0...HEAD
+[0.10.0]: https://github.com/zaproxy/action-baseline/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/zaproxy/action-baseline/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/zaproxy/action-baseline/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/zaproxy/action-baseline/compare/v0.8.0...v0.8.1

--- a/README.md
+++ b/README.md
@@ -56,13 +56,22 @@ if it identifies any alerts. Set this option to `true` if you want to fail the s
 
 **Optional** By default the baseline action will attach the report to the build with the name `zap_scan`. Set this to a different string to name it something else. Consult [GitHub's documentation](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/additional-information.md#non-supported-characters) for which artifact names are allowed.
 
+## Environment variables
+
+If set, the following [ZAP authentication environment variables](https://www.zaproxy.org/docs/authentication/handling-auth-yourself/#authentication-env-vars)
+will be copied into the docker container:
+
+- `ZAP_AUTH_HEADER_VALUE`
+- `ZAP_AUTH_HEADER`
+- `ZAP_AUTH_HEADER_SITE`
+
 ## Example usage
 
 ** Basic **
 ```
 steps:
   - name: ZAP Scan
-    uses: zaproxy/action-baseline@v0.9.0
+    uses: zaproxy/action-baseline@v0.10.0
     with:
       target: 'https://www.zaproxy.org'
 ```
@@ -82,7 +91,7 @@ jobs:
         with:
           ref: master
       - name: ZAP Scan
-        uses: zaproxy/action-baseline@v0.9.0
+        uses: zaproxy/action-baseline@v0.10.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'ghcr.io/zaproxy/zaproxy:stable'

--- a/dist/index.js
+++ b/dist/index.js
@@ -38370,7 +38370,7 @@ async function run() {
         await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +
             `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ async function run() {
         await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +
             `-t ${docker_name} zap-baseline.py -t ${target} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {


### PR DESCRIPTION
Allow to do the scans authenticated with manual auth.
Same as zaproxy/action-api-scan#9.

Update changelog and readme for release.