### PR TITLE
fix: bypass deprecation warnings by upgrading upload-artifact to v4

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -44,7 +44,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist


### PR DESCRIPTION
Example of deprecation warning:
https://github.com/Techlete/website/actions/runs/8773104919

Warning about v4 on GHES
https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new