### PR TITLE
Allow to write any file to the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update dependencies.
 
+### Fixed
+- Allow to write any file from the Docker container. [#118](https://github.com/zaproxy/action-baseline/issues/118)
+
 ## [0.12.0] - 2024-04-02
 ### Changed
 - Update dependencies.

--- a/dist/index.js
+++ b/dist/index.js
@@ -59637,9 +59637,8 @@ async function run() {
             plugins = await common.helper.processLineByLine(`${workspace}/${rulesFileLocation}`);
         }
 
-        // Create the files so we can change the perms and allow the docker non root user to update them
-        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
-        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        // Allow writing files from the Docker container.
+        await exec.exec(`chmod a+w ${workspace}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
         let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +

--- a/index.js
+++ b/index.js
@@ -46,9 +46,8 @@ async function run() {
             plugins = await common.helper.processLineByLine(`${workspace}/${rulesFileLocation}`);
         }
 
-        // Create the files so we can change the perms and allow the docker non root user to update them
-        await exec.exec(`touch ${jsonReportName} ${mdReportName} ${htmlReportName}`);
-        await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
+        // Allow writing files from the Docker container.
+        await exec.exec(`chmod a+w ${workspace}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
         let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +


### PR DESCRIPTION
Support any file not just the default reports (e.g. ZAP plan created by the baseline scan).

Fix #118.