### PR TITLE
Bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -44,7 +44,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist


### PR DESCRIPTION
See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/